### PR TITLE
Account for recent changes to JSON API Drupal module

### DIFF
--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -7,7 +7,7 @@ const {
 } = Ember;
 
 export default DS.JSONAPIAdapter.extend({
-  namespace: 'api',
+  namespace: 'jsonapi',
   drupalMapper: service(),
 
   pathForType(modelName) {
@@ -40,7 +40,6 @@ export default DS.JSONAPIAdapter.extend({
       query = this.sortQueryParams(drupalQuery);
     }
 
-    query._format = 'api_json';
     return this.ajax(url, 'GET', { data: query });
   },
 });


### PR DESCRIPTION
Change API namespace from "api" to "jsonapi", don't add "_format=api_json" query parameter any more